### PR TITLE
Add NphiesIntegrationMiddleware .NET 8 API skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+bin/
+obj/
+**/bin/
+**/obj/
+*.user
+*.vs/

--- a/NphiesIntegrationMiddleware.sln
+++ b/NphiesIntegrationMiddleware.sln
@@ -1,0 +1,33 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NphiesIntegrationMiddleware", "NphiesIntegrationMiddleware\NphiesIntegrationMiddleware.csproj", "{968AE646-C7A2-4527-B9C4-51E7AD0545D7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{84CC3EF1-2F60-43DC-AC64-5B0F1F8A102F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NphiesIntegrationMiddleware.Tests", "Tests\NphiesIntegrationMiddleware.Tests\NphiesIntegrationMiddleware.Tests.csproj", "{F0B0776D-D855-47A0-B497-632D3C6FC94E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{968AE646-C7A2-4527-B9C4-51E7AD0545D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{968AE646-C7A2-4527-B9C4-51E7AD0545D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{968AE646-C7A2-4527-B9C4-51E7AD0545D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{968AE646-C7A2-4527-B9C4-51E7AD0545D7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0B0776D-D855-47A0-B497-632D3C6FC94E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0B0776D-D855-47A0-B497-632D3C6FC94E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0B0776D-D855-47A0-B497-632D3C6FC94E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0B0776D-D855-47A0-B497-632D3C6FC94E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{F0B0776D-D855-47A0-B497-632D3C6FC94E} = {84CC3EF1-2F60-43DC-AC64-5B0F1F8A102F}
+	EndGlobalSection
+EndGlobal

--- a/NphiesIntegrationMiddleware/Controllers/ClaimsController.cs
+++ b/NphiesIntegrationMiddleware/Controllers/ClaimsController.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc;
+using NphiesIntegrationMiddleware.Models;
+using NphiesIntegrationMiddleware.FhirTransform;
+using NphiesIntegrationMiddleware.NphiesClient;
+
+namespace NphiesIntegrationMiddleware.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class ClaimsController : ControllerBase
+{
+    private readonly IFhirTransformer _transformer;
+    private readonly INphiesApiClient _client;
+    private readonly ILogger<ClaimsController> _logger;
+
+    public ClaimsController(IFhirTransformer transformer, INphiesApiClient client, ILogger<ClaimsController> logger)
+    {
+        _transformer = transformer;
+        _client = client;
+        _logger = logger;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> SubmitClaim([FromBody] ClaimRequest request)
+    {
+        _logger.LogInformation("Received claim for member {MemberId}", request.MemberId);
+        var fhirJson = _transformer.TransformToFhir(request);
+        var response = await _client.PostClaimAsync(fhirJson);
+        return StatusCode((int)response.StatusCode);
+    }
+}

--- a/NphiesIntegrationMiddleware/FhirTransform/FhirTransformer.cs
+++ b/NphiesIntegrationMiddleware/FhirTransform/FhirTransformer.cs
@@ -1,0 +1,26 @@
+using System.Text.Json;
+using NphiesIntegrationMiddleware.Models;
+
+namespace NphiesIntegrationMiddleware.FhirTransform;
+
+public interface IFhirTransformer
+{
+    string TransformToFhir(ClaimRequest request);
+}
+
+public class FhirTransformer : IFhirTransformer
+{
+    public string TransformToFhir(ClaimRequest request)
+    {
+        // This is a placeholder for real FHIR transformation
+        // In a real implementation, map the request to a FHIR resource
+        var fhirObject = new
+        {
+            resourceType = "Claim",
+            memberId = request.MemberId,
+            amount = request.Amount,
+            serviceDate = request.ServiceDate
+        };
+        return JsonSerializer.Serialize(fhirObject);
+    }
+}

--- a/NphiesIntegrationMiddleware/Logging/LoggingExtensions.cs
+++ b/NphiesIntegrationMiddleware/Logging/LoggingExtensions.cs
@@ -1,0 +1,17 @@
+using Serilog;
+
+namespace NphiesIntegrationMiddleware.Logging;
+
+public static class LoggingExtensions
+{
+    public static void ConfigureSerilog(WebApplicationBuilder builder)
+    {
+        Log.Logger = new LoggerConfiguration()
+            .ReadFrom.Configuration(builder.Configuration)
+            .Enrich.FromLogContext()
+            .WriteTo.Console()
+            .CreateLogger();
+
+        builder.Host.UseSerilog(Log.Logger, dispose: true);
+    }
+}

--- a/NphiesIntegrationMiddleware/Models/ClaimRequest.cs
+++ b/NphiesIntegrationMiddleware/Models/ClaimRequest.cs
@@ -1,0 +1,8 @@
+namespace NphiesIntegrationMiddleware.Models;
+
+public class ClaimRequest
+{
+    public string MemberId { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public string ServiceDate { get; set; } = string.Empty;
+}

--- a/NphiesIntegrationMiddleware/NphiesClient/NphiesApiClient.cs
+++ b/NphiesIntegrationMiddleware/NphiesClient/NphiesApiClient.cs
@@ -1,0 +1,26 @@
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NphiesIntegrationMiddleware.NphiesClient;
+
+public interface INphiesApiClient
+{
+    Task<HttpResponseMessage> PostClaimAsync(string fhirJson);
+}
+
+public class NphiesApiClient : INphiesApiClient
+{
+    private readonly HttpClient _httpClient;
+
+    public NphiesApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public Task<HttpResponseMessage> PostClaimAsync(string fhirJson)
+    {
+        var content = new StringContent(fhirJson, Encoding.UTF8, "application/fhir+json");
+        return _httpClient.PostAsync("/claims", content);
+    }
+}

--- a/NphiesIntegrationMiddleware/NphiesIntegrationMiddleware.csproj
+++ b/NphiesIntegrationMiddleware/NphiesIntegrationMiddleware.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.6" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+</Project>

--- a/NphiesIntegrationMiddleware/NphiesIntegrationMiddleware.http
+++ b/NphiesIntegrationMiddleware/NphiesIntegrationMiddleware.http
@@ -1,0 +1,6 @@
+@NphiesIntegrationMiddleware_HostAddress = http://localhost:5216
+
+GET {{NphiesIntegrationMiddleware_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/NphiesIntegrationMiddleware/Program.cs
+++ b/NphiesIntegrationMiddleware/Program.cs
@@ -1,0 +1,58 @@
+using NphiesIntegrationMiddleware.FhirTransform;
+using NphiesIntegrationMiddleware.NphiesClient;
+using NphiesIntegrationMiddleware.Logging;
+using Polly;
+using Polly.Extensions.Http;
+
+var builder = WebApplication.CreateBuilder(args);
+LoggingExtensions.ConfigureSerilog(builder);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+builder.Services.AddScoped<IFhirTransformer, FhirTransformer>();
+
+builder.Services
+    .AddHttpClient<INphiesApiClient, NphiesApiClient>(client =>
+    {
+        client.BaseAddress = new Uri("https://api.nphies.example.com");
+    })
+    .AddPolicyHandler(GetRetryPolicy())
+    .AddPolicyHandler(GetCircuitBreakerPolicy());
+
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+
+app.Run();
+
+static IAsyncPolicy<HttpResponseMessage> GetRetryPolicy()
+{
+    return HttpPolicyExtensions
+        .HandleTransientHttpError()
+        .WaitAndRetryAsync(3, retryAttempt =>
+            TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
+}
+
+static IAsyncPolicy<HttpResponseMessage> GetCircuitBreakerPolicy()
+{
+    return HttpPolicyExtensions
+        .HandleTransientHttpError()
+        .CircuitBreakerAsync(5, TimeSpan.FromSeconds(30));
+}

--- a/NphiesIntegrationMiddleware/Properties/launchSettings.json
+++ b/NphiesIntegrationMiddleware/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:33022",
+      "sslPort": 44309
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5216",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7018;http://localhost:5216",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/NphiesIntegrationMiddleware/appsettings.Development.json
+++ b/NphiesIntegrationMiddleware/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/NphiesIntegrationMiddleware/appsettings.json
+++ b/NphiesIntegrationMiddleware/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/ReadMe
+++ b/ReadMe
@@ -1,1 +1,19 @@
-NPHIES middleware project.
+# NphiesIntegrationMiddleware
+
+This project provides a template ASP.NET Core Web API targeting .NET 8 for integrating with the NPHIES healthcare platform.
+
+## Features
+- RESTful JSON endpoints
+- Swagger UI for testing
+- Serilog for structured logging
+- Polly-based resiliency policies
+- Sample FHIR transformation and client
+- xUnit test project
+
+## Build and test
+
+```bash
+dotnet build NphiesIntegrationMiddleware.sln
+
+dotnet test NphiesIntegrationMiddleware.sln
+```

--- a/Tests/NphiesIntegrationMiddleware.Tests/FhirTransformerTests.cs
+++ b/Tests/NphiesIntegrationMiddleware.Tests/FhirTransformerTests.cs
@@ -1,0 +1,16 @@
+using NphiesIntegrationMiddleware.FhirTransform;
+using NphiesIntegrationMiddleware.Models;
+
+namespace NphiesIntegrationMiddleware.Tests;
+
+public class FhirTransformerTests
+{
+    [Fact]
+    public void TransformToFhir_ReturnsJson()
+    {
+        var transformer = new FhirTransformer();
+        var request = new ClaimRequest { MemberId = "123", Amount = 100, ServiceDate = "2024-01-01" };
+        var result = transformer.TransformToFhir(request);
+        Assert.Contains("\"resourceType\":\"Claim\"", result);
+    }
+}

--- a/Tests/NphiesIntegrationMiddleware.Tests/GlobalUsings.cs
+++ b/Tests/NphiesIntegrationMiddleware.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Tests/NphiesIntegrationMiddleware.Tests/NphiesIntegrationMiddleware.Tests.csproj
+++ b/Tests/NphiesIntegrationMiddleware.Tests/NphiesIntegrationMiddleware.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\NphiesIntegrationMiddleware\NphiesIntegrationMiddleware.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add new Web API project targeting .NET 8
- set up Serilog logging and Polly resilience
- implement simple FHIR transformer and NPHIES client
- expose ClaimsController endpoint
- add xUnit test project
- document build and test instructions

## Testing
- `dotnet restore NphiesIntegrationMiddleware.sln`
- `dotnet test`
- `dotnet build NphiesIntegrationMiddleware.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_686acf16d4b0832d9d62294b38f0af4f