### PR TITLE
Add NphiesMiddleware skeleton

### DIFF
--- a/NphiesMiddleware/Api/Controllers/ClaimController.cs
+++ b/NphiesMiddleware/Api/Controllers/ClaimController.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using NphiesMiddleware.Core.DTOs;
+using NphiesMiddleware.Core.Interfaces;
+using Hl7.Fhir.Model;
+
+namespace NphiesMiddleware.Api.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class ClaimController : ControllerBase
+{
+    private readonly IValidationService _validator;
+    private readonly IFhirTransformerService _transformer;
+    private readonly INphiesPostingService _poster;
+    private readonly ILogger<ClaimController> _logger;
+
+    public ClaimController(IValidationService validator, IFhirTransformerService transformer, INphiesPostingService poster, ILogger<ClaimController> logger)
+    {
+        _validator = validator;
+        _transformer = transformer;
+        _poster = poster;
+        _logger = logger;
+    }
+
+    [HttpPost("claims")]
+    public async Task<IActionResult> PostClaim([FromBody] ClaimRequest request)
+    {
+        await _validator.ValidateAsync(request);
+        var resource = await _transformer.TransformAsync(request);
+        if (resource is Bundle bundle)
+        {
+            await _poster.PostBundleAsync(bundle);
+        }
+        _logger.LogInformation("Processed claim {ClaimId}", request.ClaimId);
+        return Ok();
+    }
+}

--- a/NphiesMiddleware/Core/DTOs/ClaimRequest.cs
+++ b/NphiesMiddleware/Core/DTOs/ClaimRequest.cs
@@ -1,0 +1,8 @@
+namespace NphiesMiddleware.Core.DTOs;
+
+public class ClaimRequest
+{
+    public string? ClaimId { get; set; }
+    public string? PatientId { get; set; }
+    public decimal Amount { get; set; }
+}

--- a/NphiesMiddleware/Core/DTOs/EligibilityCheck.cs
+++ b/NphiesMiddleware/Core/DTOs/EligibilityCheck.cs
@@ -1,0 +1,7 @@
+namespace NphiesMiddleware.Core.DTOs;
+
+public class EligibilityCheck
+{
+    public string? PatientId { get; set; }
+    public string? CoverageId { get; set; }
+}

--- a/NphiesMiddleware/Core/DTOs/PreAuthorization.cs
+++ b/NphiesMiddleware/Core/DTOs/PreAuthorization.cs
@@ -1,0 +1,8 @@
+namespace NphiesMiddleware.Core.DTOs;
+
+public class PreAuthorization
+{
+    public string? AuthorizationId { get; set; }
+    public string? PatientId { get; set; }
+    public decimal Amount { get; set; }
+}

--- a/NphiesMiddleware/Core/Interfaces/IFhirTransformerService.cs
+++ b/NphiesMiddleware/Core/Interfaces/IFhirTransformerService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+using Hl7.Fhir.Model;
+
+namespace NphiesMiddleware.Core.Interfaces;
+
+public interface IFhirTransformerService
+{
+    Task<Resource> TransformAsync<T>(T dto);
+}

--- a/NphiesMiddleware/Core/Interfaces/INphiesPostingService.cs
+++ b/NphiesMiddleware/Core/Interfaces/INphiesPostingService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+using Hl7.Fhir.Model;
+
+namespace NphiesMiddleware.Core.Interfaces;
+
+public interface INphiesPostingService
+{
+    Task PostBundleAsync(Bundle bundle);
+}

--- a/NphiesMiddleware/Core/Interfaces/IValidationService.cs
+++ b/NphiesMiddleware/Core/Interfaces/IValidationService.cs
@@ -1,0 +1,9 @@
+using NphiesMiddleware.Core.DTOs;
+using System.Threading.Tasks;
+
+namespace NphiesMiddleware.Core.Interfaces;
+
+public interface IValidationService
+{
+    Task ValidateAsync<T>(T dto);
+}

--- a/NphiesMiddleware/Integration/HttpPolicies.cs
+++ b/NphiesMiddleware/Integration/HttpPolicies.cs
@@ -1,0 +1,19 @@
+using Polly;
+using Polly.Extensions.Http;
+using System;
+using System.Net.Http;
+
+namespace NphiesMiddleware.Integration;
+
+public static class HttpPolicies
+{
+    public static IAsyncPolicy<HttpResponseMessage> GetRetryPolicy()
+        => HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
+
+    public static IAsyncPolicy<HttpResponseMessage> GetCircuitBreakerPolicy()
+        => HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .CircuitBreakerAsync(5, TimeSpan.FromSeconds(30));
+}

--- a/NphiesMiddleware/Integration/OAuthMessageHandler.cs
+++ b/NphiesMiddleware/Integration/OAuthMessageHandler.cs
@@ -1,0 +1,22 @@
+using System.Net.Http.Headers;
+
+namespace NphiesMiddleware.Integration;
+
+public class OAuthMessageHandler : DelegatingHandler
+{
+    private readonly IHttpClientFactory _factory;
+    private readonly IConfiguration _config;
+
+    public OAuthMessageHandler(IHttpClientFactory factory, IConfiguration config)
+    {
+        _factory = factory;
+        _config = config;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        // TODO: Retrieve token from OAuth server
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "token");
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/NphiesMiddleware/Logging/SerilogConfig.cs
+++ b/NphiesMiddleware/Logging/SerilogConfig.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+
+namespace NphiesMiddleware.Logging;
+
+public static class SerilogConfig
+{
+    public static void ConfigureSerilog(HostBuilderContext ctx, LoggerConfiguration config)
+    {
+        config.MinimumLevel.Debug()
+              .Enrich.FromLogContext()
+              .WriteTo.Console()
+              .WriteTo.File("Logs/log-.txt", rollingInterval: RollingInterval.Day)
+              .WriteTo.Seq(ctx.Configuration.GetValue<string>("Logging:SeqUrl"));
+    }
+}

--- a/NphiesMiddleware/NphiesMiddleware.csproj
+++ b/NphiesMiddleware/NphiesMiddleware.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="5.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="12.4.0" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="5.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/NphiesMiddleware/Persistence/MiddlewareDbContext.cs
+++ b/NphiesMiddleware/Persistence/MiddlewareDbContext.cs
@@ -1,0 +1,10 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace NphiesMiddleware.Persistence;
+
+public class MiddlewareDbContext : DbContext
+{
+    public MiddlewareDbContext(DbContextOptions<MiddlewareDbContext> options) : base(options) { }
+
+    // TODO: Add DbSet properties
+}

--- a/NphiesMiddleware/Program.cs
+++ b/NphiesMiddleware/Program.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi.Models;
+using Serilog;
+using Serilog.Context;
+using Serilog.Events;
+using NphiesMiddleware.Core.Interfaces;
+using NphiesMiddleware.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.UseSerilog((ctx, lc) => lc
+    .MinimumLevel.Debug()
+    .Enrich.FromLogContext()
+    .WriteTo.Console()
+    .WriteTo.File("Logs/log-.txt", rollingInterval: RollingInterval.Day)
+    .WriteTo.Seq(ctx.Configuration.GetValue<string>("Logging:SeqUrl")));
+
+builder.Services.AddControllers();
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "NPHIES Middleware API", Version = "v1" });
+});
+
+builder.Services.AddAuthentication("Bearer")
+    .AddJwtBearer();
+
+builder.Services.AddHttpClient("Nphies")
+    .AddPolicyHandler(HttpPolicies.GetRetryPolicy())
+    .AddPolicyHandler(HttpPolicies.GetCircuitBreakerPolicy());
+
+builder.Services.AddScoped<IValidationService, ValidationService>();
+builder.Services.AddScoped<IFhirTransformerService, FhirTransformerService>();
+builder.Services.AddScoped<INphiesPostingService, NphiesPostingService>();
+
+var app = builder.Build();
+
+app.UseSerilogRequestLogging();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();
+

--- a/NphiesMiddleware/README.md
+++ b/NphiesMiddleware/README.md
@@ -1,0 +1,27 @@
+# NphiesMiddleware
+
+A .NET Core 8 Web API skeleton that demonstrates a clean architecture approach for integrating with the NPHIES platform.
+
+## Structure
+
+- **Api** — Controllers exposing HTTP endpoints.
+- **Core** — Domain models, DTOs and service interfaces.
+- **Services** — Implementation of business services.
+- **Validation** — FluentValidation validators and Codex rules engine integration.
+- **Transformers** — Helpers for converting DTOs to FHIR resources.
+- **Integration** — HttpClient policies and OAuth2 helpers.
+- **Persistence** — EF Core DbContext and repositories.
+- **Logging** — Serilog configuration.
+- **Tests** — xUnit test project.
+
+## Running
+
+This project targets `.NET 8`. Install the [.NET 8 SDK](https://dotnet.microsoft.com/) and run:
+
+```bash
+cd NphiesMiddleware
+ dotnet restore
+ dotnet run
+```
+
+Then navigate to `https://localhost:5001/swagger` to view Swagger UI.

--- a/NphiesMiddleware/Services/FhirTransformerService.cs
+++ b/NphiesMiddleware/Services/FhirTransformerService.cs
@@ -1,0 +1,14 @@
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using NphiesMiddleware.Core.Interfaces;
+
+namespace NphiesMiddleware.Services;
+
+public class FhirTransformerService : IFhirTransformerService
+{
+    public Task<Resource> TransformAsync<T>(T dto)
+    {
+        // TODO: Implement mapping from DTO to FHIR Resource
+        return Task.FromResult<Resource>(new Bundle());
+    }
+}

--- a/NphiesMiddleware/Services/NphiesPostingService.cs
+++ b/NphiesMiddleware/Services/NphiesPostingService.cs
@@ -1,0 +1,24 @@
+using Hl7.Fhir.Model;
+using NphiesMiddleware.Core.Interfaces;
+
+namespace NphiesMiddleware.Services;
+
+public class NphiesPostingService : INphiesPostingService
+{
+    private readonly IHttpClientFactory _factory;
+    private readonly ILogger<NphiesPostingService> _logger;
+
+    public NphiesPostingService(IHttpClientFactory factory, ILogger<NphiesPostingService> logger)
+    {
+        _factory = factory;
+        _logger = logger;
+    }
+
+    public async Task PostBundleAsync(Bundle bundle)
+    {
+        var client = _factory.CreateClient("Nphies");
+        // TODO: Serialize bundle and post to NPHIES endpoint
+        _logger.LogInformation("Posting bundle {Id}", bundle.Id);
+        await Task.CompletedTask;
+    }
+}

--- a/NphiesMiddleware/Services/ValidationService.cs
+++ b/NphiesMiddleware/Services/ValidationService.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+using NphiesMiddleware.Core.Interfaces;
+
+namespace NphiesMiddleware.Services;
+
+public class ValidationService : IValidationService
+{
+    private readonly IServiceProvider _provider;
+
+    public ValidationService(IServiceProvider provider)
+    {
+        _provider = provider;
+    }
+
+    public async Task ValidateAsync<T>(T dto)
+    {
+        var validator = _provider.GetService<IValidator<T>>();
+        if (validator != null)
+        {
+            await validator.ValidateAndThrowAsync(dto);
+        }
+    }
+}

--- a/NphiesMiddleware/Tests/SampleTests.cs
+++ b/NphiesMiddleware/Tests/SampleTests.cs
@@ -1,0 +1,12 @@
+using Xunit;
+
+namespace NphiesMiddleware.Tests;
+
+public class SampleTests
+{
+    [Fact]
+    public void DummyTest()
+    {
+        Assert.True(true);
+    }
+}

--- a/NphiesMiddleware/Transformers/ClaimFhirTransformer.cs
+++ b/NphiesMiddleware/Transformers/ClaimFhirTransformer.cs
@@ -1,0 +1,13 @@
+using Hl7.Fhir.Model;
+using NphiesMiddleware.Core.DTOs;
+
+namespace NphiesMiddleware.Transformers;
+
+public static class ClaimFhirTransformer
+{
+    public static Bundle ToFhir(ClaimRequest request)
+    {
+        // TODO: map ClaimRequest to FHIR Claim Bundle
+        return new Bundle();
+    }
+}

--- a/NphiesMiddleware/Validation/CodexRulesEngine.cs
+++ b/NphiesMiddleware/Validation/CodexRulesEngine.cs
@@ -1,0 +1,10 @@
+namespace NphiesMiddleware.Validation;
+
+public class CodexRulesEngine
+{
+    public Task<bool> EvaluateAsync<T>(T payload)
+    {
+        // TODO: Integrate Codex Rules Engine
+        return Task.FromResult(true);
+    }
+}

--- a/NphiesMiddleware/Validation/Validators/ClaimRequestValidator.cs
+++ b/NphiesMiddleware/Validation/Validators/ClaimRequestValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using NphiesMiddleware.Core.DTOs;
+
+namespace NphiesMiddleware.Validation.Validators;
+
+public class ClaimRequestValidator : AbstractValidator<ClaimRequest>
+{
+    public ClaimRequestValidator()
+    {
+        RuleFor(x => x.ClaimId).NotEmpty();
+        RuleFor(x => x.PatientId).NotEmpty();
+        RuleFor(x => x.Amount).GreaterThan(0);
+    }
+}

--- a/NphiesMiddleware/Validation/Validators/EligibilityCheckValidator.cs
+++ b/NphiesMiddleware/Validation/Validators/EligibilityCheckValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+using NphiesMiddleware.Core.DTOs;
+
+namespace NphiesMiddleware.Validation.Validators;
+
+public class EligibilityCheckValidator : AbstractValidator<EligibilityCheck>
+{
+    public EligibilityCheckValidator()
+    {
+        RuleFor(x => x.PatientId).NotEmpty();
+        RuleFor(x => x.CoverageId).NotEmpty();
+    }
+}

--- a/NphiesMiddleware/Validation/Validators/PreAuthorizationValidator.cs
+++ b/NphiesMiddleware/Validation/Validators/PreAuthorizationValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+using NphiesMiddleware.Core.DTOs;
+
+namespace NphiesMiddleware.Validation.Validators;
+
+public class PreAuthorizationValidator : AbstractValidator<PreAuthorization>
+{
+    public PreAuthorizationValidator()
+    {
+        RuleFor(x => x.AuthorizationId).NotEmpty();
+        RuleFor(x => x.PatientId).NotEmpty();
+        RuleFor(x => x.Amount).GreaterThan(0);
+    }
+}

--- a/NphiesMiddleware/appsettings.json
+++ b/NphiesMiddleware/appsettings.json
@@ -1,0 +1,19 @@
+{
+  "Logging": {
+    "SeqUrl": "http://localhost:5341",
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=NphiesDb;Trusted_Connection=True;"
+  },
+  "Nphies": {
+    "BaseUrl": "https://nphies.example.com/api",
+    "ClientId": "client-id",
+    "ClientSecret": "client-secret",
+    "TokenUrl": "https://nphies.example.com/oauth/token"
+  }
+}


### PR DESCRIPTION
## Summary
- create `.NET 8` Web API skeleton for `NphiesMiddleware`
- set up Serilog, Swagger and sample controllers
- add DTOs, services and validation stubs
- configure HttpClient policies and OAuth handler
- include EF Core DbContext and test project

## Testing
- `dotnet test NphiesMiddleware/Tests/SampleTests.cs --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad2b6b56c832da58e72a716a798e2